### PR TITLE
#88: fix dynamic label in mw-switch; add tests

### DIFF
--- a/mwui-stencil/src/components/mw-switch/mw-switch.spec.tsx
+++ b/mwui-stencil/src/components/mw-switch/mw-switch.spec.tsx
@@ -28,4 +28,28 @@ describe("GIVEN MwSwitch", () => {
 
     expect(page.root.shadowRoot.querySelector(".label").innerHTML).toEqual(label);
   });
+
+  it("SHOULD render off-text label WHEN value is false", async () => {
+    const offText = "off-text";
+    const onText = "on-text";
+    const page = await setup({
+      checked: false,
+      offText,
+      onText,
+    });
+
+    expect(page.root.shadowRoot.querySelector(".label").innerHTML).toEqual(offText);
+  });
+
+  it("SHOULD render on-text label WHEN value is true", async () => {
+    const offText = "off-text";
+    const onText = "on-text";
+    const page = await setup({
+      checked: true,
+      offText,
+      onText,
+    });
+
+    expect(page.root.shadowRoot.querySelector(".label").innerHTML).toEqual(onText);
+  });
 });

--- a/mwui-stencil/src/components/mw-switch/mw-switch.tsx
+++ b/mwui-stencil/src/components/mw-switch/mw-switch.tsx
@@ -44,7 +44,6 @@ export class MwSwitch {
 
   private toggleSwitch(event: Event & { path: unknown[] }): void {
     (event.target as HTMLInputElement).blur();
-    (event.path[1] as HTMLInputElement).blur();
     this.checked = this.checkbox.checked;
     this.emitter.emit(event);
   }


### PR DESCRIPTION
Not sure why we had this line in there anyways, but it threw an error that prevented the toggling logic to be executed